### PR TITLE
Feature/read environment variable from global config

### DIFF
--- a/app/code/community/Inviqa/SymfonyContainer/Model/ConfigurationBuilder.php
+++ b/app/code/community/Inviqa/SymfonyContainer/Model/ConfigurationBuilder.php
@@ -7,6 +7,8 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilder
     const MODEL_ALIAS = 'inviqa_symfonyContainer';
 
     const CACHED_CONTAINER = 'container.cache.php';
+    const ENVIRONMENT_NODE = 'global/environment';
+    const TEST_ENVIRONMENT = 'test';
 
     /**
      * @param array $services Awkward way of passing deps to spec mage object
@@ -25,13 +27,16 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilder
     {
         $servicesFormat = 'xml';
         $cachedContainer = $this->_baseDir . '/' . self::CACHED_CONTAINER;
-
-        return Configuration::fromParameters(
+        $configuration = Configuration::fromParameters(
             $cachedContainer,
             $this->_collectConfigFolders(),
             !$this->_app->useCache(self::MODEL_ALIAS),
             $servicesFormat
         );
+
+        $configuration->setTestEnvironment($this->_isTestEnvironment());
+
+        return $configuration;
     }
 
     /**
@@ -58,5 +63,13 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilder
         }
 
         return $folders;
+    }
+
+    /**
+     * @return bool
+     */
+    private function _isTestEnvironment()
+    {
+        return $this->_config->getNode(self::ENVIRONMENT_NODE) === self::TEST_ENVIRONMENT;
     }
 }

--- a/app/code/spec/Inviqa/SymfonyContainer/Helper/ContainerProviderSpec.php
+++ b/app/code/spec/Inviqa/SymfonyContainer/Helper/ContainerProviderSpec.php
@@ -17,6 +17,7 @@ class Inviqa_SymfonyContainer_Helper_ContainerProviderSpec extends ObjectBehavio
         $generatorConfig->getServicesFolders()->willReturn(['app/etc']);
         $generatorConfig->getServicesFormat()->willReturn('xml');
         $generatorConfig->getCompilerPasses()->willReturn([]);
+        $generatorConfig->isTestEnvironment()->willReturn(false);
 
         $services = [
             'generatorConfig' => $generatorConfig

--- a/app/code/spec/Inviqa/SymfonyContainer/Model/ConfigurationBuilderSpec.php
+++ b/app/code/spec/Inviqa/SymfonyContainer/Model/ConfigurationBuilderSpec.php
@@ -15,6 +15,8 @@ use Prophecy\Argument;
 
 class Inviqa_SymfonyContainer_Model_ConfigurationBuilderSpec extends ObjectBehavior
 {
+    const TEST_ENVIRONMENT = 'test';
+
     function let(MageApp $app, MageConfig $config, MageConfigOptions $configOptions, MageConfigNode $configNode)
     {
         $configNode->children()->willReturn([]);
@@ -23,6 +25,7 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilderSpec extends ObjectBehav
 
         $config->getOptions()->willReturn($configOptions);
         $config->getNode('modules')->willReturn($configNode);
+        $config->getNode('global/environment')->willReturn();
 
         $services = [
             'app' => $app,
@@ -92,5 +95,13 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilderSpec extends ObjectBehav
         $configuration = $this->build();
 
         $configuration->getServicesFolders()->shouldBe(['app/etc', 'app/module1/etc']);
+    }
+
+    function it_builds_a_generator_configuration_and_sets_test_environment_to_true(MageConfig $config)
+    {
+        $config->getNode('global/environment')->willReturn(self::TEST_ENVIRONMENT);
+        $configuration = $this->build();
+
+        $configuration->isTestEnvironment()->shouldBe(true);
     }
 }


### PR DESCRIPTION
This PR allows the `isTestEnvironment()` check to rely on the Magento `global/environment` configuration.
