### PR TITLE
Add version requirement for magento version checker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
         "psr-0": {
             "": "app/code/community"
         }
+    },
+    "extra": {
+        "magento-version-ee": "^1.12.0"
     }
 }


### PR DESCRIPTION
Without it the mage symfony container is not usable with modules or mage installations, which use magento version checker.
