### PR TITLE
Add support for custom compiler passes

### DIFF
--- a/app/code/community/Bridge/MageApp.php
+++ b/app/code/community/Bridge/MageApp.php
@@ -6,4 +6,6 @@ interface MageApp
     public function useCache($model);
 
     public function getStore($id = null);
+
+    public function dispatchEvent($eventName, $args);
 }

--- a/app/code/community/Inviqa/SymfonyContainer/Helper/ContainerProvider.php
+++ b/app/code/community/Inviqa/SymfonyContainer/Helper/ContainerProvider.php
@@ -2,11 +2,18 @@
 
 use ContainerTools\Configuration;
 use ContainerTools\ContainerGenerator;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Container;
+use Bridge\MageApp;
 
 class Inviqa_SymfonyContainer_Helper_ContainerProvider
 {
     const HELPER_NAME = 'inviqa_symfonyContainer/containerProvider';
+
+    /**
+     * @var Mage_Core_Model_App
+     */
+    private $_mageApp;
 
     /**
      * @var Container
@@ -22,7 +29,6 @@ class Inviqa_SymfonyContainer_Helper_ContainerProvider
      * @var CompilerPassInterface
      */
     private $_storeConfigCompilerPass;
-
     /**
      * @var CompilerPassInterface
      */
@@ -30,6 +36,8 @@ class Inviqa_SymfonyContainer_Helper_ContainerProvider
 
     public function __construct(array $services = array())
     {
+        $this->_mageApp = isset($services['app']) ? $services['app'] : Mage::app();
+
         $this->_generatorConfig = isset($services['generatorConfig']) ?
             $services['generatorConfig'] :
             Mage::getModel('inviqa_symfonyContainer/configurationBuilder')->build();
@@ -58,6 +66,11 @@ class Inviqa_SymfonyContainer_Helper_ContainerProvider
     {
         $this->_generatorConfig->addCompilerPass($this->_storeConfigCompilerPass);
         $this->_generatorConfig->addCompilerPass($this->_injectableCompilerPass);
+
+        $this->_mageApp->dispatchEvent(
+            'symfony_container_before_container_generator',
+            ['generator_config' => $this->_generatorConfig]
+        );
 
         $generator = new ContainerGenerator($this->_generatorConfig);
 

--- a/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
+++ b/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
@@ -12,9 +12,15 @@ class Inviqa_SymfonyContainer_Model_Observer
     public function onCacheRefresh(Varien_Event_Observer $event)
     {
         if (ConfigurationBuilder::MODEL_ALIAS === $event->getType()) {
-            $filePath = Mage::getBaseDir('cache') . '/' . ConfigurationBuilder::CACHED_CONTAINER;
-            if (file_exists($filePath)) {
-                unlink($filePath);
+            $containerFilePath = Mage::getBaseDir('cache') . '/' . ConfigurationBuilder::CACHED_CONTAINER;
+            $metaFilePath = Mage::getBaseDir('cache') . '/' . ConfigurationBuilder::CACHED_CONTAINER . '.meta';
+
+            if (file_exists($containerFilePath)) {
+                unlink($containerFilePath);
+            }
+
+            if (file_exists($metaFilePath)) {
+                unlink($metaFilePath);
             }
         }
     }

--- a/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
+++ b/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
@@ -7,13 +7,14 @@ class Inviqa_SymfonyContainer_Model_Observer
 {
     use Inviqa_SymfonyContainer_Helper_ServiceProvider;
 
+    const CACHE_META_SUFFIX = '.meta';
     const SERVICE_INJECTOR = 'inviqa_symfonyContainer/serviceInjector';
 
     public function onCacheRefresh(Varien_Event_Observer $event)
     {
         if (ConfigurationBuilder::MODEL_ALIAS === $event->getType()) {
-            $containerFilePath = Mage::getBaseDir('cache') . '/' . ConfigurationBuilder::CACHED_CONTAINER;
-            $metaFilePath = Mage::getBaseDir('cache') . '/' . ConfigurationBuilder::CACHED_CONTAINER . '.meta';
+            $containerFilePath = $this->containerCachePath();
+            $metaFilePath = $this->containerCacheMetaPath();
 
             if (file_exists($containerFilePath)) {
                 unlink($containerFilePath);
@@ -31,5 +32,15 @@ class Inviqa_SymfonyContainer_Model_Observer
         Mage::getSingleton(self::SERVICE_INJECTOR, [
             'container' => Mage::helper(ContainerProvider::HELPER_NAME)->getContainer()
         ])->setupDependencies($controller);
+    }
+
+    private function containerCachePath()
+    {
+        return Mage::getBaseDir('cache') . DIRECTORY_SEPARATOR . ConfigurationBuilder::CACHED_CONTAINER;
+    }
+
+    private function containerCacheMetaPath()
+    {
+        return $this->containerCachePath() . self::CACHE_META_SUFFIX;
     }
 }

--- a/app/code/spec/Inviqa/SymfonyContainer/Helper/ContainerProviderSpec.php
+++ b/app/code/spec/Inviqa/SymfonyContainer/Helper/ContainerProviderSpec.php
@@ -44,7 +44,7 @@ class Inviqa_SymfonyContainer_Helper_ContainerProviderSpec extends ObjectBehavio
         $this->getContainer()->shouldBeAnInstanceOf(Container::class);
     }
 
-    function it_memorizes_the_container(
+    function it_memoizes_the_container(
         MageApp $app,
         Configuration $generatorConfig,
         StoreConfigCompilerPass $configCompilerPass,


### PR DESCRIPTION
- [x] Add support for custom compiler passes

```
Dispatch custom "symfony_container_before_container_generator" Magento event
before container compiler passes are registered.

This will allow any Magento observer listening to the above event to inject
custom compiler passes into the configuration object just before the
container is created.
```
- [x]   Delete cache meta file during cache clear

```
The latest versin of this library also creates a "container.cache.php.meta"
file when the container is cached.
Updated the Magento observer to also remove this file if it exists when
the Magento cache clear event is triggered.
```
## How to register a custom compiler pass?
- create a custom compiler pass class in your project (e.g. https://github.com/inviqa/magento-symfony-container/blob/master/app/code/community/Inviqa/SymfonyContainer/Model/InjectableCompilerPass.php)
- create a Magento observer and configure it to listen to the `symfony_container_before_container_generator` Magento event
- update the above observer to inject the custom compiler pass into the generator config, as shown below:

``` php
class Inviqa_DependencyInjection_Model_Observer
{
    /** @var CustomCompilerPass */
    private $customCompilerPass;

    public function __construct()
    {
        $this->customCompilerPass = new CustomCompilerPass();
    }

    public function onBeforeContainerGenerator(Varien_Event_Observer $observer)
    {
        /** @var Configuration $generatorConfig */
        $generatorConfig = $observer->getData('generator_config');

        $generatorConfig->addCompilerPass($this->customCompilerPass);
    }
}
```
