### PR TITLE
Listen to cache:flush events

### DIFF
--- a/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
+++ b/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
@@ -12,19 +12,12 @@ class Inviqa_SymfonyContainer_Model_Observer
 
     public function onCacheRefresh(Varien_Event_Observer $event)
     {
-        if (ConfigurationBuilder::MODEL_ALIAS === $event->getType()) {
-            $containerFilePath = $this->containerCachePath();
-            $metaFilePath = $this->containerCacheMetaPath();
-
-            if (file_exists($containerFilePath)) {
-                unlink($containerFilePath);
-            }
-
-            if (file_exists($metaFilePath)) {
-                unlink($metaFilePath);
-            }
+        $eventType = $event->getType();
+        if ($eventType === ConfigurationBuilder::MODEL_ALIAS || is_null($eventType)) {
+            $this->clearCache();
         }
     }
+
     public function onPreDispatch(Varien_Event_Observer $event)
     {
         $controller = $event->getControllerAction();
@@ -32,6 +25,20 @@ class Inviqa_SymfonyContainer_Model_Observer
         Mage::getSingleton(self::SERVICE_INJECTOR, [
             'container' => Mage::helper(ContainerProvider::HELPER_NAME)->getContainer()
         ])->setupDependencies($controller);
+    }
+
+    private function clearCache()
+    {
+        $containerFilePath = $this->containerCachePath();
+        $metaFilePath = $this->containerCacheMetaPath();
+
+        if (file_exists($containerFilePath)) {
+            unlink($containerFilePath);
+        }
+
+        if (file_exists($metaFilePath)) {
+            unlink($metaFilePath);
+        }
     }
 
     private function containerCachePath()

--- a/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
+++ b/app/code/community/Inviqa/SymfonyContainer/Model/Observer.php
@@ -12,10 +12,14 @@ class Inviqa_SymfonyContainer_Model_Observer
 
     public function onCacheRefresh(Varien_Event_Observer $event)
     {
-        $eventType = $event->getType();
-        if ($eventType === ConfigurationBuilder::MODEL_ALIAS || is_null($eventType)) {
+        if ($event->getType() === ConfigurationBuilder::MODEL_ALIAS) {
             $this->clearCache();
         }
+    }
+
+    public function onCacheFlush()
+    {
+        $this->clearCache();
     }
 
     public function onPreDispatch(Varien_Event_Observer $event)

--- a/app/code/community/Inviqa/SymfonyContainer/etc/config.xml
+++ b/app/code/community/Inviqa/SymfonyContainer/etc/config.xml
@@ -22,6 +22,24 @@
                     </inviqa_symfonyContainer>
                 </observers>
             </adminhtml_cache_refresh_type>
+            <adminhtml_cache_flush_all>
+                <observers>
+                    <inviqa_symfonyContainer>
+                        <class>Inviqa_SymfonyContainer_Model_Observer</class>
+                        <type>singleton</type>
+                        <method>onCacheRefresh</method>
+                    </inviqa_symfonyContainer>
+                </observers>
+            </adminhtml_cache_flush_all>
+            <adminhtml_cache_flush_system>
+                <observers>
+                    <inviqa_symfonyContainer>
+                        <class>Inviqa_SymfonyContainer_Model_Observer</class>
+                        <type>singleton</type>
+                        <method>onCacheRefresh</method>
+                    </inviqa_symfonyContainer>
+                </observers>
+            </adminhtml_cache_flush_system>
             <controller_action_predispatch>
                 <observers>
                     <inviqa_symfonyContainer>

--- a/app/code/community/Inviqa/SymfonyContainer/etc/config.xml
+++ b/app/code/community/Inviqa/SymfonyContainer/etc/config.xml
@@ -27,7 +27,7 @@
                     <inviqa_symfonyContainer>
                         <class>Inviqa_SymfonyContainer_Model_Observer</class>
                         <type>singleton</type>
-                        <method>onCacheRefresh</method>
+                        <method>onCacheFlush</method>
                     </inviqa_symfonyContainer>
                 </observers>
             </adminhtml_cache_flush_all>
@@ -36,7 +36,7 @@
                     <inviqa_symfonyContainer>
                         <class>Inviqa_SymfonyContainer_Model_Observer</class>
                         <type>singleton</type>
-                        <method>onCacheRefresh</method>
+                        <method>onCacheFlush</method>
                     </inviqa_symfonyContainer>
                 </observers>
             </adminhtml_cache_flush_system>


### PR DESCRIPTION
- if magerun cache:flush runs
- if admin is pressing on "flush magento cache"
- if admin is pressing on "flush cache storage"

Then the DI container files should be removed accordingly.
This also fixes a bug when during capistrano deployments, the container were not cleaned up (as 99% of times only magerun cache:flush is called)
