### PR TITLE
Fix checking active modules

### DIFF
--- a/app/code/community/Inviqa/SymfonyContainer/Model/ConfigurationBuilder.php
+++ b/app/code/community/Inviqa/SymfonyContainer/Model/ConfigurationBuilder.php
@@ -71,7 +71,7 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilder
     private function _addModuleFolders($folders)
     {
         foreach ($this->_config->getNode('modules')->children() as $name => $module) {
-            if ($module->active) {
+            if ((string) $module->active == 'true') {
                 $folders[] = $this->_config->getModuleDir('etc', $name);
             }
         }

--- a/app/code/spec/Inviqa/SymfonyContainer/Model/ConfigurationBuilderSpec.php
+++ b/app/code/spec/Inviqa/SymfonyContainer/Model/ConfigurationBuilderSpec.php
@@ -64,10 +64,10 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilderSpec extends ObjectBehav
     {
         $configNode->children()->willReturn([
             'module1' => (object)[
-                'active' => true
+                'active' => 'true'
             ],
             'module2' => (object)[
-                'active' => true
+                'active' => 'true'
             ]
         ]);
 
@@ -83,10 +83,10 @@ class Inviqa_SymfonyContainer_Model_ConfigurationBuilderSpec extends ObjectBehav
     {
         $configNode->children()->willReturn([
             'module1' => (object)[
-                'active' => true
+                'active' => 'true'
             ],
             'module2' => (object)[
-                'active' => false
+                'active' => 'false'
             ]
         ]);
 


### PR DESCRIPTION
As the `$module->active` reference itself is an XML node, this `if` condition was always evaluated to true.
Also, the XML node's content is string, and not boolean as the code assumed.