### PR TITLE
Loosen magento-composer-installer requirement for composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "Provides Magento with an instance of a Symfony DI Container",
     "require": {
         "inviqa/symfony-container-generator": "^1.0",
-        "magento-hackathon/magento-composer-installer": "^3.0"
+        "magento-hackathon/magento-composer-installer": ">= 3.0.0"
     },
     "require-dev": {
         "phpspec/phpspec": "^2.2"


### PR DESCRIPTION
https://github.com/Cotya/magento-composer-installer/releases/tag/4.0.1 adds support for composer v2, but we can't pull it in at the moment due to requiring 3.2.3

Until merged/released, if you are stuck you can add this to your "require" section:
```json
"magento-hackathon/magento-composer-installer": "4.0.1 as 3.2.3",
```